### PR TITLE
Fixed README link typo in okta.com/

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This repo let's you see the OAuth 2.0 Implicit flow and the Authorization Code w
 
 The Implicit flow is effectively deprecated and should no longer be used.
 
-You need a free [Okta Developer Org](https://developer.okta.con/signup) to get started.
+You need a free [Okta Developer Org](https://developer.okta.com/signup) to get started.
 
 In the admin console of your Okta org, Navigate to: **Applications**
 


### PR DESCRIPTION
okta.com instead of okta.con/