### PR TITLE
Make sure example works with okta-oauth-js 2.6.2

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -37,6 +37,7 @@ export function validateAccess(to, from, next) {
 export function loginOkta(grantType) {
     oktaAuth.options.grantType = grantType;
     oktaAuth.token.getWithRedirect({
+        pkce: true,
         responseType: responseTypes[grantType],
         scopes: ['openid', 'profile', 'email']
     });
@@ -81,4 +82,4 @@ export function getIdToken() {
 export function getAccessToken() {
     return oktaAuth.tokenManager.get('access_token');
 }
-  
+


### PR DESCRIPTION
In okta-oauth-js, a new `pkce` option was introduced. Without setting
this option to true while calling `getWithRedirect`, no PKCE
code_challenge will be used, so it will not be a PKCE request. By adding
the option and setting it to `true` in the options passed to
`getWithRedirect`, the request will be a PKCE request, making the
example work again.

Adding this is needed, as the okta-oauth-js dependency is locked up to
the next minor version, and although a breaking change (PKCE not working
without the option being set), it was added in a patch version.